### PR TITLE
Default to Manifest V3

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -46,7 +46,7 @@ export function Sidebar() {
   }
 
   const browsers: Browser[] = ["Chrome", "Firefox", "Safari"];
-  const manifestVersions: ManifestVersion[] = ["MV2", "MV3"];
+  const manifestVersions: ManifestVersion[] = ["MV3", "MV2"];
 
   return (
     <div

--- a/src/components/StateProvider/StateProvider.tsx
+++ b/src/components/StateProvider/StateProvider.tsx
@@ -30,7 +30,7 @@ function getInitialState(): PlaygroundState {
       (hashState && templates.find((t) => t.id === hashState.templateId)) ??
       templates[0],
     selectedBrowser: hashState?.browser ?? "Chrome",
-    manifestVersion: hashState?.manifestVersion ?? "MV2",
+    manifestVersion: hashState?.manifestVersion ?? "MV3",
     includePolyfill: hashState?.includePolyfill ?? false,
     theme: "Dark",
     initialEditorState: hashState && {


### PR DESCRIPTION
Changes the default manifest version to MV3. This is a better starting point for Chrome (which is currently the default browser), and is supported in Firefox and Safari too.