### PR TITLE
Add new Side Panel template

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -91,6 +91,11 @@
         }
       }
 
+      &[data-disabled="true"] {
+        opacity: 0.6;
+        pointer-events: none;
+      }
+
       svg {
         margin-left: 5px;
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -64,6 +64,7 @@ export function Sidebar() {
         <ul>
           {templates.map((t) => (
             <li
+              data-disabled={t.filter?.(playgroundState) === false}
               data-selected={selectedTemplate === t ? "true" : undefined}
               onClick={() => {
                 setStateWithConfirmation({ selectedTemplate: t });
@@ -77,6 +78,7 @@ export function Sidebar() {
         <ul>
           {browsers.map((b: Browser) => (
             <li
+              data-disabled={selectedTemplate.filter?.({ ...playgroundState, selectedBrowser: b }) === false}
               data-selected={selectedBrowser === b ? "true" : undefined}
               onClick={() => setStateWithConfirmation({ selectedBrowser: b })}
             >

--- a/src/templates/sidePanel.ts
+++ b/src/templates/sidePanel.ts
@@ -1,0 +1,43 @@
+import { Template } from "./index";
+
+export const SidePanel: Template = {
+  id: "sidePanel",
+  name: "Side Panel",
+  manifest: {
+    name: "Side Panel",
+    description: "Basic Side Panel Extension",
+    backgroundScripts: ["background.js"],
+    permissions: {
+      sidePanel: true,
+    },
+    sidepanelPath: "sidepanel.html",
+  },
+  files: [
+    {
+      name: "background.ts",
+      text: (global) =>
+        `
+${global}.runtime.onInstalled.addListener((details) => {
+  console.log("Extension has been installed. Reason:", details.reason);
+});
+
+console.log("Hello World!");
+      `.trim(),
+    },
+    {
+      name: "sidepanel.html",
+      text: () =>
+        `
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
+</html>
+      `.trim(),
+    },
+  ],
+  // Side Panel is not currently supported in Safari
+  filter: (state) =>
+    state.selectedBrowser === "Chrome" || state.selectedBrowser === "Firefox",
+};


### PR DESCRIPTION
This also introduces a new filter system (since Side Panel UIs aren't supported in Safari) and a way of declaring permissions in the manifest (declared as an object so we can make smart decisions when generating the manifest based on the browser, like not including the sidePanel permission in Firefox where it isn't needed).