### PR TITLE
Use latest chrome-types package

### DIFF
--- a/src/utils/sandbox.ts
+++ b/src/utils/sandbox.ts
@@ -19,7 +19,7 @@ export async function loadSandbox(): Promise<Sandbox> {
   const browserTypes = await browserTypesResponse.text();
 
   const chromeTypesResponse = await fetch(
-    "https://unpkg.com/@types/chrome@0.0.190/index.d.ts"
+    "https://unpkg.com/@types/chrome@latest/index.d.ts"
   );
   const chromeTypes = await chromeTypesResponse.text();
 


### PR DESCRIPTION
I'm honestly not sure why this was locked to a version. Removing that restriction so the latest APIs are available.