### PR TITLE
Upgrade monaco-editor version

### DIFF
--- a/build_workers.sh
+++ b/build_workers.sh
@@ -1,0 +1,8 @@
+ROOT=$PWD/node_modules/monaco-editor/esm/vs
+OPTS="--no-source-maps"        # Parcel options - See: https://parceljs.org/cli.html
+
+npx parcel build $ROOT/language/json/json.worker.js $OPTS
+npx parcel build $ROOT/language/css/css.worker.js $OPTS
+npx parcel build $ROOT/language/html/html.worker.js $OPTS
+npx parcel build $ROOT/language/typescript/ts.worker.js $OPTS
+npx parcel build $ROOT/editor/editor.worker.js $OPTS

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@typescript/sandbox": "0.1.0",
+        "@typescript/sandbox": "0.1.2",
         "jszip": "^3.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -17,48 +17,50 @@
         "react-modal": "^3.15.1"
       },
       "devDependencies": {
-        "@parcel/transformer-sass": "^2.6.2",
+        "@parcel/transformer-sass": "2.12.0",
         "@types/react-dom": "^18.0.5",
         "@types/react-modal": "^3.13.1",
         "@typescript/vfs": "^1.3.5",
         "buffer": "^6.0.3",
-        "monaco-editor": "^0.32.1",
-        "parcel": "^2.6.2",
+        "monaco-editor": "0.45.0",
+        "parcel": "2.12.0",
         "prettier": "2.7.1",
         "process": "^0.11.10",
         "typescript": "^4.7.4"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -126,64 +128,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@lezer/common": {
       "version": "0.15.12",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
@@ -200,9 +144,9 @@
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
+      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +157,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
+      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
       "cpu": [
         "x64"
       ],
@@ -226,9 +170,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
+      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
       "cpu": [
         "arm"
       ],
@@ -239,9 +183,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
+      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
       "cpu": [
         "arm64"
       ],
@@ -252,9 +196,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
+      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
       "cpu": [
         "x64"
       ],
@@ -265,9 +209,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
+      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
       "cpu": [
         "x64"
       ],
@@ -292,9 +236,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
-      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
       "cpu": [
         "arm64"
       ],
@@ -305,9 +249,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
-      "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
       "cpu": [
         "x64"
       ],
@@ -318,9 +262,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
-      "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
       "cpu": [
         "arm"
       ],
@@ -331,9 +275,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
-      "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
       "cpu": [
         "arm64"
       ],
@@ -344,9 +288,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
-      "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
       "cpu": [
         "x64"
       ],
@@ -357,9 +301,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
-      "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
       "cpu": [
         "x64"
       ],
@@ -370,20 +314,21 @@
       ]
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.7.0.tgz",
-      "integrity": "sha512-PU5MtWWhc+dYI9x8mguYnm9yiG6TkI7niRpxgJgtqAyGHuEyNXVBQQ0X+qyOF4D9LdankBf8uNN18g31IET2Zg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
+      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -391,15 +336,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.7.0.tgz",
-      "integrity": "sha512-JlXNoZXcWzLKdDlfeF3dIj5Vtel5T9vtdBN72PJ+cjC4qNHk4Uwvc5sfOBELuibGN0bVu2bwY9nUgSwCiB1iIA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
+      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "lmdb": "2.5.2"
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "lmdb": "2.8.5"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -409,13 +354,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
-      "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
+      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -429,16 +374,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.7.0.tgz",
-      "integrity": "sha512-SCXwnOOQT6EmpusBsYWNQ/RFri+2JnKuE0gMSf2dROl2xbererX45FYzeDplWALCKAdjMNDpFwU+FyMYoVZSCQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
+      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -446,70 +391,72 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.7.0.tgz",
-      "integrity": "sha512-ZzsLr97AYrz8c9k6qn3DlqPzifi3vbP7q3ynUrAFxmt0L4+K0H9N508ZkORYmCgaFjLIQ8Y3eWpwCJ0AewPNIg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
+      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.7.0",
-        "@parcel/compressor-raw": "2.7.0",
-        "@parcel/namer-default": "2.7.0",
-        "@parcel/optimizer-css": "2.7.0",
-        "@parcel/optimizer-htmlnano": "2.7.0",
-        "@parcel/optimizer-image": "2.7.0",
-        "@parcel/optimizer-svgo": "2.7.0",
-        "@parcel/optimizer-terser": "2.7.0",
-        "@parcel/packager-css": "2.7.0",
-        "@parcel/packager-html": "2.7.0",
-        "@parcel/packager-js": "2.7.0",
-        "@parcel/packager-raw": "2.7.0",
-        "@parcel/packager-svg": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/resolver-default": "2.7.0",
-        "@parcel/runtime-browser-hmr": "2.7.0",
-        "@parcel/runtime-js": "2.7.0",
-        "@parcel/runtime-react-refresh": "2.7.0",
-        "@parcel/runtime-service-worker": "2.7.0",
-        "@parcel/transformer-babel": "2.7.0",
-        "@parcel/transformer-css": "2.7.0",
-        "@parcel/transformer-html": "2.7.0",
-        "@parcel/transformer-image": "2.7.0",
-        "@parcel/transformer-js": "2.7.0",
-        "@parcel/transformer-json": "2.7.0",
-        "@parcel/transformer-postcss": "2.7.0",
-        "@parcel/transformer-posthtml": "2.7.0",
-        "@parcel/transformer-raw": "2.7.0",
-        "@parcel/transformer-react-refresh-wrap": "2.7.0",
-        "@parcel/transformer-svg": "2.7.0"
+        "@parcel/bundler-default": "2.12.0",
+        "@parcel/compressor-raw": "2.12.0",
+        "@parcel/namer-default": "2.12.0",
+        "@parcel/optimizer-css": "2.12.0",
+        "@parcel/optimizer-htmlnano": "2.12.0",
+        "@parcel/optimizer-image": "2.12.0",
+        "@parcel/optimizer-svgo": "2.12.0",
+        "@parcel/optimizer-swc": "2.12.0",
+        "@parcel/packager-css": "2.12.0",
+        "@parcel/packager-html": "2.12.0",
+        "@parcel/packager-js": "2.12.0",
+        "@parcel/packager-raw": "2.12.0",
+        "@parcel/packager-svg": "2.12.0",
+        "@parcel/packager-wasm": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/resolver-default": "2.12.0",
+        "@parcel/runtime-browser-hmr": "2.12.0",
+        "@parcel/runtime-js": "2.12.0",
+        "@parcel/runtime-react-refresh": "2.12.0",
+        "@parcel/runtime-service-worker": "2.12.0",
+        "@parcel/transformer-babel": "2.12.0",
+        "@parcel/transformer-css": "2.12.0",
+        "@parcel/transformer-html": "2.12.0",
+        "@parcel/transformer-image": "2.12.0",
+        "@parcel/transformer-js": "2.12.0",
+        "@parcel/transformer-json": "2.12.0",
+        "@parcel/transformer-postcss": "2.12.0",
+        "@parcel/transformer-posthtml": "2.12.0",
+        "@parcel/transformer-raw": "2.12.0",
+        "@parcel/transformer-react-refresh-wrap": "2.12.0",
+        "@parcel/transformer-svg": "2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-7yKZUdh314Q/kU/9+27ZYTfcnXS6VYHuG+iiUlIohnvUUybxLqVJhdMU9Q+z2QcPka1IdJWz4K4Xx0y6/4goyg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
+      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/graph": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -517,25 +464,9 @@
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
         "json5": "^2.2.0",
-        "msgpackr": "^1.5.4",
+        "msgpackr": "^1.9.9",
         "nullthrows": "^1.1.1",
-        "semver": "^5.7.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.14.0.tgz",
-      "integrity": "sha512-r5tJWe6NF6lesfPw1N3g7N7WUKpHqi2ONnw9wl5ccSGGIxkmgcPaPQxfvmhdjXvQnktSuIOR0HjQXVXu+/en/w==",
-      "dev": true,
-      "dependencies": {
-        "lightningcss": "^1.14.0"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -546,9 +477,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
-      "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
+      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -563,9 +494,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.7.0.tgz",
-      "integrity": "sha512-kQDwMKgZ1U4M/G17qeDYF6bW5kybluN6ajYPc7mZcrWg+trEI/oXi81GMFaMX0BSUhwhbiN5+/Vb2wiG/Sn6ig==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
+      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -576,16 +507,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.7.0.tgz",
-      "integrity": "sha512-PU5fo4Hh8y03LZgemgVREttc0wyHQUNmsJCybxTB7EjJie2CqJRumo+DFppArlvdchLwJdc9em03yQV/GNWrEg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
+      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.7.0"
+        "@parcel/rust": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -595,32 +526,15 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
-      }
-    },
-    "node_modules/@parcel/fs-search": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.7.0.tgz",
-      "integrity": "sha512-K1Hv25bnRpwQVA15RvcRuB8ZhfclnCHA8N8L6w7Ul1ncSJDxCIkIAc5hAubYNNYW3kWjCC2SOaEgFKnbvMllEQ==",
-      "dev": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.7.0.tgz",
-      "integrity": "sha512-Q6E94GS6q45PtsZh+m+gvFRp/N1Qopxhu2sxjcWsGs5iBd6IWn2oYLWOH5iVzEjWuYpW2HkB08lH6J50O63uOA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
+      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
       "dev": true,
       "dependencies": {
-        "@parcel/utils": "2.7.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -631,31 +545,14 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/hash": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.7.0.tgz",
-      "integrity": "sha512-k6bSKnIlPJMPU3yjQzfgfvF9zuJZGOAlJgzpL4BbWvdbE8BTdjzLcFn0Ujrtud94EgIkiXd22sC2HpCUWoHGdA==",
-      "dev": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "xxhash-wasm": "^0.4.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
+      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -666,9 +563,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
-      "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
+      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -682,18 +579,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.7.0.tgz",
-      "integrity": "sha512-lIKMdsmi//7fepecNDYmJYzBlL91HifPsX03lJCdu1dC6q5fBs+gG0XjKKG7yPnSCw1qH/4m7drzt9+dRZYAHQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
+      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -701,15 +598,18 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.7.0.tgz",
-      "integrity": "sha512-5UJQHalqMxdhJIs2hhqQzFfQpF7+NAowsRq064lYtiRvcD8wMr3OOQ9wd1iazGpFSl4JKdT7BwDU9/miDJmanQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
+      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -720,22 +620,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.7.0.tgz",
-      "integrity": "sha512-IfnOMACqhcAclKyOW9X9JpsknB6OShk9OVvb8EvbDTKHJhQHNNmzE88OkSI/pS3ZVZP9Zj+nWcVHguV+kvDeiQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
+      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -743,12 +643,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.7.0.tgz",
-      "integrity": "sha512-5QrGdWS5Hi4VXE3nQNrGqugmSXt68YIsWwKRAdarOxzyULSJS3gbCiQOXqIPRJobfZjnSIcdtkyxSiCUe1inIA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
+      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.12.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -756,70 +656,209 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/csso": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "dev": true,
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
+        "stable": "^0.1.8"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.7.0.tgz",
-      "integrity": "sha512-EnaXz5UjR67FUu0BEcqZTT9LsbB/iFAkkghCotbnbOuC5QQsloq6tw54TKU3y+R3qsjgUoMtGxPcGfVoXxZXYw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
+      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "detect-libc": "^1.0.3"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.7.0.tgz",
-      "integrity": "sha512-IO1JV4NpfP3V7FrhsqCcV8pDQIHraFi1/ZvEJyssITxjH49Im/txKlwMiQuZZryAPn8Xb8g395Muawuk6AK6sg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
+      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/optimizer-terser": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.7.0.tgz",
-      "integrity": "sha512-07VZjIO8xsl2/WmS/qHI8lI/cpu47iS9eRpqwfZEEsdk1cfz50jhWkmFudHBxiHGMfcZ//1+DdaPg9RDBWZtZA==",
+    "node_modules/@parcel/optimizer-svgo/node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
-        "nullthrows": "^1.1.1",
-        "terser": "^5.2.0"
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/csso": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "dev": true
+    },
+    "node_modules/@parcel/optimizer-svgo/node_modules/svgo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "dev": true,
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
+        "stable": "^0.1.8"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@parcel/optimizer-swc": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
+      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
+        "@swc/core": "^1.3.36",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -827,18 +866,20 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.7.0.tgz",
-      "integrity": "sha512-wmfSX1mRrTi8MeA4KrnPk/x7zGUsILCQmTo6lA4gygzAxDbM1pGuyFN8/Kt0y0SFO2lbljARtD/4an5qdotH+Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
+      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "semver": "^5.7.1"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/core": "^1.3.36",
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -848,23 +889,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.7.0.tgz",
-      "integrity": "sha512-44nzZwu+ssGuiFmYM6cf/Y4iChiUZ4DUzzpegnGlhXtKJKe4NHntxThJynuRZWKN2AAf48avApDpimg2jW0KDw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
+      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -872,20 +915,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.7.0.tgz",
-      "integrity": "sha512-Zgqd7sdcY/UnR370GR0q2ilmEohUDXsO8A1F28QCJzIsR1iCB6KRUT74+pawfQ1IhXZLaaFLLYe0UWcfm0JeXg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
+      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -893,22 +936,23 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.7.0.tgz",
-      "integrity": "sha512-wTRdM81PgRVDzWGXdWmqLwguWnTYWzhEDdjXpW2n8uMOu/CjHhMtogk65aaYk3GOnq6OBL/NsrmBiV/zKPj1vA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
+      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -916,16 +960,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.7.0.tgz",
-      "integrity": "sha512-jg2Zp8dI5VpIQlaeahXDCfrPN9m/DKht1NkR9P2CylMAwqCcc1Xc1RRiF0wfwcPZpPMpq1265n+4qnB7rjGBlA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
+      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -933,19 +977,36 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.7.0.tgz",
-      "integrity": "sha512-EmJg3HpD6/xxKBjir/CdCKJZwI24iVfBuxRS9LUp3xHAIebOzVh1z6IN+i2Di5+NyRwfOFaLliL4uMa1zwbyCA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
+      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-wasm": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
+      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.12.0"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -953,12 +1014,30 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.7.0.tgz",
-      "integrity": "sha512-qqgx+nnMn6/0lRc4lKbLGmhNtBiT93S2gFNB4Eb4Pfz/SxVYoW+fmml+KdfOSiZffWOAH5L6NwhyD7N8aSikzw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
+      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.7.0"
+        "@parcel/types": "2.12.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/profiler": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
+      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "chrome-trace-event": "^1.0.2"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -969,20 +1048,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.7.0.tgz",
-      "integrity": "sha512-80gEODg8cnAmnxGVuaSVDo8JJ54P9AA2bHwSs1cIkHWlJ3BjDQb83H31bBHncJ5Kn5kQ/j+7WjlqHpTCiOR9PA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.12.0.tgz",
+      "integrity": "sha512-TqKsH4GVOLPSCanZ6tcTPj+rdVHERnt5y4bwTM82cajM21bCX1Ruwp8xOKU+03091oV2pv5ieB18pJyRF7IpIw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -990,17 +1069,37 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.7.0.tgz",
-      "integrity": "sha512-ySuou5addK8fGue8aXzo536BaEjMujDrEc1xkp4TasInXHVcA98b+SYX5NAZTGob5CxKvZQ5ylhg77zW30B+iA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
+      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/reporter-tracer": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
+      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "chrome-trace-event": "^1.0.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1008,17 +1107,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.7.0.tgz",
-      "integrity": "sha512-v8TvWsbLK7/q7n4gv6OrYNbW18xUx4zKbVMGZb1u4yMhzEH4HFr1D9OeoTq3jk+ximAigds8B6triQbL5exF7A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
+      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "2.7.0",
-        "@parcel/plugin": "2.7.0"
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1026,17 +1125,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.7.0.tgz",
-      "integrity": "sha512-PLbMLdclQeYsi2LkilZVGFV1n3y55G1jaBvby4ekedUZjMw3SWdMY2tDxgSDdFWfLCnYHJXdGUQSzGGi1kPzjA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
+      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1044,18 +1143,19 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.7.0.tgz",
-      "integrity": "sha512-9/YUZTBNrSN2H6rbz/o1EOM0O7I3ZR/x9IDzxjJBD6Mi+0uCgCD02aedare/SNr1qgnbZZWmhpOzC+YgREcfLA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
+      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1063,19 +1163,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.7.0.tgz",
-      "integrity": "sha512-vDKO0rWqRzEpmvoZ4kkYUiSsTxT5NnH904BFPFxKI0wJCl6yEmPuEifmATo73OuYhP6jIP3Qfl1R4TtiDFPJ1Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
+      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1083,18 +1183,31 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.7.0.tgz",
-      "integrity": "sha512-uD2pAV0yV6+e7JaWH4KVPbG+zRCrxr/OACyS9tIh+Q/R1vRmh8zGM3yhdrcoiZ7tFOnM72vd6xY11eTrUsSVig==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
+      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
+      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1102,9 +1215,9 @@
       }
     },
     "node_modules/@parcel/source-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
-      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
+      "integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -1114,23 +1227,23 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.7.0.tgz",
-      "integrity": "sha512-7iklDXXnKH1530+QbI+e4kIJ+Q1puA1ulRS10db3aUJMj5GnvXGDFwhSZ7+T1ps66QHO7cVO29VlbqiRDarH1Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
+      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "semver": "^5.7.0"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1138,22 +1251,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.7.0.tgz",
-      "integrity": "sha512-J4EpWK9spQpXyNCmKK8Xnane0xW/1B/EAmfp7Fiv7g+5yUjY4ODf4KUugvE+Eb2gekPkhOKNHermO2KrX0/PFA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
+      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1161,23 +1274,24 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.7.0.tgz",
-      "integrity": "sha512-wYJl5rn81W+Rlk9oQwDJcjoVsWVDKyeri84FzmlGXOsg0EYgnqOiG+3MDM8GeZjfuGe5fuoum4eqZeS0WdUHXw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
+      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
         "posthtml-render": "^3.0.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2",
+        "srcset": "4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1185,66 +1299,66 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.7.0.tgz",
-      "integrity": "sha512-mhi9/R5/ULhCkL2COVIKhNFoLDiZwQgprdaTJr5fnODggVxEX5o7ebFV6KNLMTEkwZUJWoB1hL0ziI0++DtoFA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
+      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.7.0.tgz",
-      "integrity": "sha512-mzerR+D4rDomUSIk5RSTa2w+DXBdXUeQrpDO74WCDdpDi1lIl8ppFpqtmU7O6y6p8QsgkmS9b0g/vhcry6CJTA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
+      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "@swc/helpers": "^0.4.2",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
-        "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
         "regenerator-runtime": "^0.13.7",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.7.0.tgz",
-      "integrity": "sha512-RQjuxBpYOch+kr4a0zi77KJtOLTPYRM7iq4NN80zKnA0r0dwDUCxZBtaj2l0O0o3R4MMJnm+ncP+cB7XR7dZYA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
+      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.12.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1252,23 +1366,23 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.7.0.tgz",
-      "integrity": "sha512-b6RskXBWf0MjpC9qjR2dQ1ZdRnlOiKYseG5CEovWCqM218RtdydFKz7jS+5Gxkb6qBtOG7zGPONXdPe+gTILcA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
+      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1276,22 +1390,22 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.7.0.tgz",
-      "integrity": "sha512-cP8YOiSynWJ1ycmBlhnnHeuQb2cwmklZ+BNyLUktj5p78kDy2de7VjX+dRNRHoW4H9OgEcSF4UEfDVVz5RYIhw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
+      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
         "posthtml-render": "^3.0.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1299,16 +1413,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.7.0.tgz",
-      "integrity": "sha512-sDnItWCFSDez0izK1i5cgv+kXzZTbcJh4rNpVIgmE1kBLvAz608sqgcCkavb2wVJIvLesxYM+5G4p1CwkDlZ1g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
+      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1316,18 +1430,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.7.0.tgz",
-      "integrity": "sha512-1vRmIJzyBA1nIiXTAU6tZExq2FvJj/2F0ft6KDw8GYPv0KjmdiPo/PmaZ7JeSVOM6SdXQIQCbTmp1vkMP7DtkA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
+      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1335,18 +1449,18 @@
       }
     },
     "node_modules/@parcel/transformer-sass": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.7.0.tgz",
-      "integrity": "sha512-6m2T6Y5eQLX7ckIeuOjXXIZbzhyovnl69AvJ2FujoWb2nA55H/kg6ZdbKjo3CfXkOfg9LyG3nVnOE5PMgMpRFQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.12.0.tgz",
+      "integrity": "sha512-xLLoSLPST+2AHJwFRLl4foArDjjy6P1RChP3TxMU2MVS1sbKGJnfFhFpHAacH8ASjuGtu5rbpfpHRZePlvoZxw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
         "sass": "^1.38.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1354,23 +1468,23 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.7.0.tgz",
-      "integrity": "sha512-ioER37zceuuE+K6ZrnjCyMUWEnv+63hIAFResc1OXxRhyt+7kzMz9ZqK0Mt6QMLwl1dxhkLmrU41n9IxzKZuSQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
+      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
         "posthtml-render": "^3.0.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.7.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1378,33 +1492,34 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-+dhXVUnseTCpJvBTGMp0V6X13z6O/A/+CUtwEpMGZ8XSmZ4Gk44GvaTiBOp0bJpWG4fvCKp+UmC8PYbrDiiziw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.12.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
-      "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
+      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/markdown-ansi": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "chalk": "^4.1.0"
+        "@parcel/codeframe": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/markdown-ansi": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0",
+        "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1415,15 +1530,270 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.5.tgz",
-      "integrity": "sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
+      "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
-        "node-addon-api": "^3.2.1",
-        "node-gyp-build": "^4.3.0"
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.4.1",
+        "@parcel/watcher-darwin-arm64": "2.4.1",
+        "@parcel/watcher-darwin-x64": "2.4.1",
+        "@parcel/watcher-freebsd-x64": "2.4.1",
+        "@parcel/watcher-linux-arm-glibc": "2.4.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.4.1",
+        "@parcel/watcher-linux-arm64-musl": "2.4.1",
+        "@parcel/watcher-linux-x64-glibc": "2.4.1",
+        "@parcel/watcher-linux-x64-musl": "2.4.1",
+        "@parcel/watcher-win32-arm64": "2.4.1",
+        "@parcel/watcher-win32-ia32": "2.4.1",
+        "@parcel/watcher-win32-x64": "2.4.1"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1433,16 +1803,16 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.7.0.tgz",
-      "integrity": "sha512-99VfaOX+89+RaoTSyH9ZQtkMBFZBFMvJmVJ/GeJT6QCd2wtKBStTHlaSnQOkLD/iRjJCNwV2xpZmm8YkTwV+hg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
+      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "chrome-trace-event": "^1.0.2",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -1453,16 +1823,229 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.7.0"
+        "@parcel/core": "^2.12.0"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.17.tgz",
+      "integrity": "sha512-tq+mdWvodMBNBBZbwFIMTVGYHe9N7zvEaycVVjfvAx20k1XozHbHhRv+9pEVFJjwRxLdXmtvFZd3QZHRAOpoNQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.2",
+        "@swc/types": "^0.1.5"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.4.17",
+        "@swc/core-darwin-x64": "1.4.17",
+        "@swc/core-linux-arm-gnueabihf": "1.4.17",
+        "@swc/core-linux-arm64-gnu": "1.4.17",
+        "@swc/core-linux-arm64-musl": "1.4.17",
+        "@swc/core-linux-x64-gnu": "1.4.17",
+        "@swc/core-linux-x64-musl": "1.4.17",
+        "@swc/core-win32-arm64-msvc": "1.4.17",
+        "@swc/core-win32-ia32-msvc": "1.4.17",
+        "@swc/core-win32-x64-msvc": "1.4.17"
+      },
+      "peerDependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.17.tgz",
+      "integrity": "sha512-HVl+W4LezoqHBAYg2JCqR+s9ife9yPfgWSj37iIawLWzOmuuJ7jVdIB7Ee2B75bEisSEKyxRlTl6Y1Oq3owBgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.17.tgz",
+      "integrity": "sha512-WYRO9Fdzq4S/he8zjW5I95G1zcvyd9yyD3Tgi4/ic84P5XDlSMpBDpBLbr/dCPjmSg7aUXxNQqKqGkl6dQxYlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.17.tgz",
+      "integrity": "sha512-cgbvpWOvtMH0XFjvwppUCR+Y+nf6QPaGu6AQ5hqCP+5Lv2zO5PG0RfasC4zBIjF53xgwEaaWmGP5/361P30X8Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.17.tgz",
+      "integrity": "sha512-l7zHgaIY24cF9dyQ/FOWbmZDsEj2a9gRFbmgx2u19e3FzOPuOnaopFj0fRYXXKCmtdx+anD750iBIYnTR+pq/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.17.tgz",
+      "integrity": "sha512-qhH4gr9gAlVk8MBtzXbzTP3BJyqbAfUOATGkyUtohh85fPXQYuzVlbExix3FZXTwFHNidGHY8C+ocscI7uDaYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.17.tgz",
+      "integrity": "sha512-vRDFATL1oN5oZMImkwbgSHEkp8xG1ofEASBypze01W1Tqto8t+yo6gsp69wzCZBlxldsvPpvFZW55Jq0Rn+UnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.17.tgz",
+      "integrity": "sha512-zQNPXAXn3nmPqv54JVEN8k2JMEcMTQ6veVuU0p5O+A7KscJq+AGle/7ZQXzpXSfUCXlLMX4wvd+rwfGhh3J4cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.17.tgz",
+      "integrity": "sha512-z86n7EhOwyzxwm+DLE5NoLkxCTme2lq7QZlDjbQyfCxOt6isWz8rkW5QowTX8w9Rdmk34ncrjSLvnHOeLY17+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.17.tgz",
+      "integrity": "sha512-JBwuSTJIgiJJX6wtr4wmXbfvOswHFj223AumUrK544QV69k60FJ9q2adPW9Csk+a8wm1hLxq4HKa2K334UHJ/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.17.tgz",
+      "integrity": "sha512-jFkOnGQamtVDBm3MF5Kq1lgW8vx4Rm1UvJWRUfg+0gx7Uc3Jp3QMFeMNw/rDNQYRDYPG3yunCC+2463ycd5+dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
+    },
     "node_modules/@swc/helpers": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
-      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
+      "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+      "dev": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@trysound/sax": {
@@ -1473,12 +2056,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -1522,35 +2099,26 @@
       "dev": true
     },
     "node_modules/@typescript/ata": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@typescript/ata/-/ata-0.9.3.tgz",
-      "integrity": "sha512-/mETZakA5iOT8j8N8/ZUPLEsvSgMJz+cWt9Le1Q9dEwRXwDzekKXw3tpgrq77gaSxgE/Mn/nvtx8uzS41CmZKQ==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@typescript/ata/-/ata-0.9.4.tgz",
+      "integrity": "sha512-PaJ16WouPV/SaA+c0tnOKIqYq24+m93ipl/e0Dkxuianer+ibc5b0/6ZgfCFF8J7QEp57dySMSP9nWOFaCfJnw==",
       "peerDependencies": {
         "typescript": "^4.4.4"
       }
     },
     "node_modules/@typescript/sandbox": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript/sandbox/-/sandbox-0.1.0.tgz",
-      "integrity": "sha512-f2pUCF3aNk3cdOuL0M7k8Vgzl4/P3ltgoZ5QWILqwp8Fb3SqLPKFSlTIKmn7Y8B7ojSz0tNQsZwH1syN6gAoSw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@typescript/sandbox/-/sandbox-0.1.2.tgz",
+      "integrity": "sha512-ncMaLNwC76leRfRvzkZn5oujEb/7EPqWuPfObG/mJWyjXNmct1PW9+cruJDUCU7Ntc4K10oMf3HEYZCp6FCs3Q==",
       "dependencies": {
-        "@typescript/ata": "0.9.3",
-        "@typescript/vfs": "1.3.5"
-      }
-    },
-    "node_modules/@typescript/sandbox/node_modules/@typescript/vfs": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.3.5.tgz",
-      "integrity": "sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==",
-      "dependencies": {
-        "debug": "^4.1.1"
+        "@typescript/ata": "0.9.4",
+        "@typescript/vfs": "1.5.0"
       }
     },
     "node_modules/@typescript/vfs": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.4.0.tgz",
-      "integrity": "sha512-Pood7yv5YWMIX+yCHo176OnF8WUlKGImFG7XlsuH14Zb1YN5+dYD3uUtS7lqZtsH7tAveNUi2NzdpQCN0yRbaw==",
-      "dev": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.0.tgz",
+      "integrity": "sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==",
       "dependencies": {
         "debug": "^4.1.1"
       }
@@ -1560,18 +2128,6 @@
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
       "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
       "dev": true
-    },
-    "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1600,6 +2156,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -1709,12 +2271,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1725,9 +2281,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001399",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
-      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
+      "version": "1.0.30001614",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz",
+      "integrity": "sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==",
       "dev": true,
       "funding": [
         {
@@ -1737,6 +2293,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -1833,49 +2393,100 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+    "node_modules/css-select/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/css-what": {
@@ -1891,16 +2502,43 @@
       }
     },
     "node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "css-tree": "^1.1.2"
+        "css-tree": "~2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.1",
@@ -2113,9 +2751,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2137,22 +2775,22 @@
       }
     },
     "node_modules/htmlnano": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
-      "integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.0.tgz",
+      "integrity": "sha512-jVGRE0Ep9byMBKEu0Vxgl8dhXYOUk0iNQ2pjsG+BcRB0u0oDF5A9p/iBGMg/PGKYUyMD0OAGu8dVT5Lzj8S58g==",
       "dev": true,
       "dependencies": {
-        "cosmiconfig": "^7.0.1",
+        "cosmiconfig": "^8.0.0",
         "posthtml": "^0.16.5",
         "timsort": "^0.3.0"
       },
       "peerDependencies": {
-        "cssnano": "^5.0.11",
+        "cssnano": "^6.0.0",
         "postcss": "^8.3.11",
-        "purgecss": "^4.0.3",
+        "purgecss": "^5.0.0",
         "relateurl": "^0.2.7",
-        "srcset": "^5.0.0",
-        "svgo": "^2.8.0",
+        "srcset": "4.0.0",
+        "svgo": "^3.0.2",
         "terser": "^5.10.0",
         "uncss": "^0.17.3"
       },
@@ -2181,6 +2819,47 @@
         "uncss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/htmlnano/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlnano/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/htmlparser2": {
@@ -2318,6 +2997,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2356,9 +3047,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.14.0.tgz",
-      "integrity": "sha512-Vwa1JWiLGRLntf4TXRu/zF2RaHRfJjbZwUzkl2C4LhnRQzsEwkyeAQjAxtpJ5NDnVVUf10q1olEzkFF4AWZLOw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.1.tgz",
+      "integrity": "sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -2371,20 +3062,21 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.14.0",
-        "lightningcss-darwin-x64": "1.14.0",
-        "lightningcss-linux-arm-gnueabihf": "1.14.0",
-        "lightningcss-linux-arm64-gnu": "1.14.0",
-        "lightningcss-linux-arm64-musl": "1.14.0",
-        "lightningcss-linux-x64-gnu": "1.14.0",
-        "lightningcss-linux-x64-musl": "1.14.0",
-        "lightningcss-win32-x64-msvc": "1.14.0"
+        "lightningcss-darwin-arm64": "1.24.1",
+        "lightningcss-darwin-x64": "1.24.1",
+        "lightningcss-freebsd-x64": "1.24.1",
+        "lightningcss-linux-arm-gnueabihf": "1.24.1",
+        "lightningcss-linux-arm64-gnu": "1.24.1",
+        "lightningcss-linux-arm64-musl": "1.24.1",
+        "lightningcss-linux-x64-gnu": "1.24.1",
+        "lightningcss-linux-x64-musl": "1.24.1",
+        "lightningcss-win32-x64-msvc": "1.24.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.14.0.tgz",
-      "integrity": "sha512-AFt8Qs9Qjbg5AlB/3cYljanVEeyJI4C9bPqO8hI7bNa2HdDIINI4NgfGpri8BNwA3zcAlFPH38caIqcG3LWC+g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.1.tgz",
+      "integrity": "sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==",
       "cpu": [
         "arm64"
       ],
@@ -2402,9 +3094,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.14.0.tgz",
-      "integrity": "sha512-xF9YSNxHiAOyYp5/Ogo4K+SybcQExWUi+vkIGnpO6zQsQda7KFgJt2aA3AwaEj9ouf2yUHHKcsk2TiixlZTtTg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.1.tgz",
+      "integrity": "sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==",
       "cpu": [
         "x64"
       ],
@@ -2421,10 +3113,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.1.tgz",
+      "integrity": "sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.14.0.tgz",
-      "integrity": "sha512-8cH/qwZnoU3zIruVNWGLBDVm6f1w/ZC3eMDkFOTEF4FaW3jCpxEg/BH5r04lNUM/SO6Zu2C+vgJaEKdUm58dQg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.1.tgz",
+      "integrity": "sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==",
       "cpu": [
         "arm"
       ],
@@ -2442,9 +3154,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.14.0.tgz",
-      "integrity": "sha512-88NmNwTRa10MRDJa2DghZuGZq8rvFeZIm0G4k/oA2P5XaJJw7f6IhDEjCtBoruYOZhulBkEq2xQY+q0AWYMFcw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.1.tgz",
+      "integrity": "sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==",
       "cpu": [
         "arm64"
       ],
@@ -2462,9 +3174,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.14.0.tgz",
-      "integrity": "sha512-8FSXmV7yPqk+1vErgdEO6OvDXDT/MkJMF+jSaUuL5wEvCC5yiJsaktNEJvn5EHsFbODi9DNvUt71sjeFCJma1w==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.1.tgz",
+      "integrity": "sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==",
       "cpu": [
         "arm64"
       ],
@@ -2482,9 +3194,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.14.0.tgz",
-      "integrity": "sha512-+dcNezLgUdAozcc6c0YSnZyRcOpro/yOOdy6ZjIwQtxej/5sEVJhXWbyHhdwSSlJssg/d+/7ihxEJIdZ8oDIfw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.1.tgz",
+      "integrity": "sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==",
       "cpu": [
         "x64"
       ],
@@ -2502,9 +3214,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.14.0.tgz",
-      "integrity": "sha512-TI8tIaYv6SBpoBGatCG8gKQMxMCUcc+rvBSrqU7geHFBwzzyxOEHflENMclfwiYjTEM/HMdgJbWuHsIY3xvkuQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.1.tgz",
+      "integrity": "sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==",
       "cpu": [
         "x64"
       ],
@@ -2522,9 +3234,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.14.0.tgz",
-      "integrity": "sha512-l2H8GoDn+WJAENKrIgNgRunqP3gvyBQwBmFqIXpuxx9G6ll2aTlyQsvsVxzJWJ5ePl3atNRGFQO+ZkiTNSm71A==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.1.tgz",
+      "integrity": "sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==",
       "cpu": [
         "x64"
       ],
@@ -2548,31 +3260,34 @@
       "dev": true
     },
     "node_modules/lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.8.5.tgz",
+      "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "msgpackr": "^1.5.4",
-        "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.3",
-        "ordered-binary": "^1.2.4",
+        "msgpackr": "^1.9.5",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.1.1",
+        "ordered-binary": "^1.4.1",
         "weak-lru-cache": "^1.2.2"
       },
+      "bin": {
+        "download-lmdb-prebuilds": "bin/download-prebuilds.js"
+      },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2"
+        "@lmdb/lmdb-darwin-arm64": "2.8.5",
+        "@lmdb/lmdb-darwin-x64": "2.8.5",
+        "@lmdb/lmdb-linux-arm": "2.8.5",
+        "@lmdb/lmdb-linux-arm64": "2.8.5",
+        "@lmdb/lmdb-linux-x64": "2.8.5",
+        "@lmdb/lmdb-win32-x64": "2.8.5"
       }
     },
     "node_modules/lmdb/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true
     },
     "node_modules/loose-envify": {
@@ -2586,16 +3301,43 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/monaco-editor": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.32.1.tgz",
-      "integrity": "sha512-LUt2wsUvQmEi2tfTOK+tjAPvt7eQ+K5C4rZPr6SeuyzjAuAHrIvlUloTcOiGjZW3fn3a/jFQCONrEJbNOaCqbA==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.45.0.tgz",
+      "integrity": "sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==",
       "dev": true
     },
     "node_modules/ms": {
@@ -2604,62 +3346,75 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msgpackr": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.2.tgz",
-      "integrity": "sha512-bqSQ0DYJbXbrJcrZFmMygUZmqQiDfI2ewFVWcrZY12w5XHWtPuW4WppDT/e63Uu311ajwkRRXSoF0uILroBeTA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "dev": true,
       "optionalDependencies": {
-        "msgpackr-extract": "^2.0.2"
+        "msgpackr-extract": "^3.0.2"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
-      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "node-gyp-build-optional-packages": "5.0.3"
+        "node-gyp-build-optional-packages": "5.0.7"
       },
       "bin": {
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "dev": true
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+    "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
       "dev": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
-      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
-      "dev": true,
+      "optional": true,
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
+      "dev": true
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/node-releases": {
@@ -2704,9 +3459,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.3.0.tgz",
-      "integrity": "sha512-knIeYepTI6BDAzGxqFEDGtI/iGqs57H32CInAIxEvAHG46vk1Di0CEpyc1A7iY39B1mfik3g3KLYwOTNnnMHLA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
+      "integrity": "sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A==",
       "dev": true
     },
     "node_modules/pako": {
@@ -2715,25 +3470,25 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parcel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.7.0.tgz",
-      "integrity": "sha512-pRYwnivwtNP0tip8xYSo4zCB0XhLt7/gJzP1p8OovCqkmFjG9VG+GW9TcAKqMIo0ovEa9tT+/s6gY1Qy+BONGQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
+      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.7.0",
-        "@parcel/core": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/reporter-cli": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/config-default": "2.12.0",
+        "@parcel/core": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/reporter-cli": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/reporter-tracer": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
-        "get-port": "^4.2.0",
-        "v8-compile-cache": "^2.0.0"
+        "get-port": "^4.2.0"
       },
       "bin": {
         "parcel": "lib/bin.js"
@@ -3003,9 +3758,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "node_modules/resolve-from": {
@@ -3063,12 +3818,18 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/setimmediate": {
@@ -3094,14 +3855,16 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+    "node_modules/srcset": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
       "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stable": {
@@ -3137,24 +3900,30 @@
       }
     },
     "node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
       },
       "bin": {
         "svgo": "bin/svgo"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
       }
     },
     "node_modules/term-size": {
@@ -3168,30 +3937,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
     },
     "node_modules/timsort": {
       "version": "0.3.0",
@@ -3212,9 +3957,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/type-fest": {
@@ -3273,19 +4018,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
     },
     "node_modules/warning": {
       "version": "4.0.3",
@@ -3301,47 +4040,40 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
     },
-    "node_modules/xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
     }
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3396,55 +4128,6 @@
         }
       }
     },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true
-    },
-    "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "@lezer/common": {
       "version": "0.15.12",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
@@ -3461,44 +4144,44 @@
       }
     },
     "@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
+      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
+      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
+      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
+      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
+      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
+      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
       "dev": true,
       "optional": true
     },
@@ -3514,148 +4197,151 @@
       }
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.1.2.tgz",
-      "integrity": "sha512-TyVLn3S/+ikMDsh0gbKv2YydKClN8HaJDDpONlaZR+LVJmsxLFUgA+O7zu59h9+f9gX1aj/ahw9wqa6rosmrYQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.1.2.tgz",
-      "integrity": "sha512-YPXtcVkhmVNoMGlqp81ZHW4dMxK09msWgnxtsDpSiZwTzUBG2N+No2bsr7WMtBKCVJMSD6mbAl7YhKUqkp/Few==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.1.2.tgz",
-      "integrity": "sha512-42R4MAFeIeNn+L98qwxAt360bwzX2Kf0ZQkBBucJ2Ircza3asoY4CDbgiu9VWklq8gWJVSJSJBwDI+c/THiWkA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.1.2.tgz",
-      "integrity": "sha512-vHZ2JiOWF2+DN9lzltGbhtQNzDo8fKFGrf37UJrgqxU0yvtERrzUugnfnX1wmVfFhSsF8OxrfqiNOUc5hko1Zg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.1.2.tgz",
-      "integrity": "sha512-RjRoRxg7Q3kPAdUSC5EUUPlwfMkIVhmaRTIe+cqHbKrGZ4M6TyCA/b5qMaukQ/1CHWrqYY2FbKOAU8Hg0pQFzg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
       "dev": true,
       "optional": true
     },
     "@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.1.2.tgz",
-      "integrity": "sha512-rIZVR48zA8hGkHIK7ED6+ZiXsjRCcAVBJbm8o89OKAMTmEAQ2QvoOxoiu3w2isAaWwzgtQIOFIqHwvZDyLKCvw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
       "dev": true,
       "optional": true
     },
     "@parcel/bundler-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.7.0.tgz",
-      "integrity": "sha512-PU5MtWWhc+dYI9x8mguYnm9yiG6TkI7niRpxgJgtqAyGHuEyNXVBQQ0X+qyOF4D9LdankBf8uNN18g31IET2Zg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
+      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.7.0.tgz",
-      "integrity": "sha512-JlXNoZXcWzLKdDlfeF3dIj5Vtel5T9vtdBN72PJ+cjC4qNHk4Uwvc5sfOBELuibGN0bVu2bwY9nUgSwCiB1iIA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
+      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "lmdb": "2.5.2"
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "lmdb": "2.8.5"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
-      "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
+      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.7.0.tgz",
-      "integrity": "sha512-SCXwnOOQT6EmpusBsYWNQ/RFri+2JnKuE0gMSf2dROl2xbererX45FYzeDplWALCKAdjMNDpFwU+FyMYoVZSCQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
+      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/config-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.7.0.tgz",
-      "integrity": "sha512-ZzsLr97AYrz8c9k6qn3DlqPzifi3vbP7q3ynUrAFxmt0L4+K0H9N508ZkORYmCgaFjLIQ8Y3eWpwCJ0AewPNIg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
+      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.7.0",
-        "@parcel/compressor-raw": "2.7.0",
-        "@parcel/namer-default": "2.7.0",
-        "@parcel/optimizer-css": "2.7.0",
-        "@parcel/optimizer-htmlnano": "2.7.0",
-        "@parcel/optimizer-image": "2.7.0",
-        "@parcel/optimizer-svgo": "2.7.0",
-        "@parcel/optimizer-terser": "2.7.0",
-        "@parcel/packager-css": "2.7.0",
-        "@parcel/packager-html": "2.7.0",
-        "@parcel/packager-js": "2.7.0",
-        "@parcel/packager-raw": "2.7.0",
-        "@parcel/packager-svg": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/resolver-default": "2.7.0",
-        "@parcel/runtime-browser-hmr": "2.7.0",
-        "@parcel/runtime-js": "2.7.0",
-        "@parcel/runtime-react-refresh": "2.7.0",
-        "@parcel/runtime-service-worker": "2.7.0",
-        "@parcel/transformer-babel": "2.7.0",
-        "@parcel/transformer-css": "2.7.0",
-        "@parcel/transformer-html": "2.7.0",
-        "@parcel/transformer-image": "2.7.0",
-        "@parcel/transformer-js": "2.7.0",
-        "@parcel/transformer-json": "2.7.0",
-        "@parcel/transformer-postcss": "2.7.0",
-        "@parcel/transformer-posthtml": "2.7.0",
-        "@parcel/transformer-raw": "2.7.0",
-        "@parcel/transformer-react-refresh-wrap": "2.7.0",
-        "@parcel/transformer-svg": "2.7.0"
+        "@parcel/bundler-default": "2.12.0",
+        "@parcel/compressor-raw": "2.12.0",
+        "@parcel/namer-default": "2.12.0",
+        "@parcel/optimizer-css": "2.12.0",
+        "@parcel/optimizer-htmlnano": "2.12.0",
+        "@parcel/optimizer-image": "2.12.0",
+        "@parcel/optimizer-svgo": "2.12.0",
+        "@parcel/optimizer-swc": "2.12.0",
+        "@parcel/packager-css": "2.12.0",
+        "@parcel/packager-html": "2.12.0",
+        "@parcel/packager-js": "2.12.0",
+        "@parcel/packager-raw": "2.12.0",
+        "@parcel/packager-svg": "2.12.0",
+        "@parcel/packager-wasm": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/resolver-default": "2.12.0",
+        "@parcel/runtime-browser-hmr": "2.12.0",
+        "@parcel/runtime-js": "2.12.0",
+        "@parcel/runtime-react-refresh": "2.12.0",
+        "@parcel/runtime-service-worker": "2.12.0",
+        "@parcel/transformer-babel": "2.12.0",
+        "@parcel/transformer-css": "2.12.0",
+        "@parcel/transformer-html": "2.12.0",
+        "@parcel/transformer-image": "2.12.0",
+        "@parcel/transformer-js": "2.12.0",
+        "@parcel/transformer-json": "2.12.0",
+        "@parcel/transformer-postcss": "2.12.0",
+        "@parcel/transformer-posthtml": "2.12.0",
+        "@parcel/transformer-raw": "2.12.0",
+        "@parcel/transformer-react-refresh-wrap": "2.12.0",
+        "@parcel/transformer-svg": "2.12.0"
       }
     },
     "@parcel/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-7yKZUdh314Q/kU/9+27ZYTfcnXS6VYHuG+iiUlIohnvUUybxLqVJhdMU9Q+z2QcPka1IdJWz4K4Xx0y6/4goyg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
+      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/graph": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -3663,24 +4349,15 @@
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
         "json5": "^2.2.0",
-        "msgpackr": "^1.5.4",
+        "msgpackr": "^1.9.9",
         "nullthrows": "^1.1.1",
-        "semver": "^5.7.1"
-      }
-    },
-    "@parcel/css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@parcel/css/-/css-1.14.0.tgz",
-      "integrity": "sha512-r5tJWe6NF6lesfPw1N3g7N7WUKpHqi2ONnw9wl5ccSGGIxkmgcPaPQxfvmhdjXvQnktSuIOR0HjQXVXu+/en/w==",
-      "dev": true,
-      "requires": {
-        "lightningcss": "^1.14.0"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
-      "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
+      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -3688,572 +4365,908 @@
       }
     },
     "@parcel/events": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.7.0.tgz",
-      "integrity": "sha512-kQDwMKgZ1U4M/G17qeDYF6bW5kybluN6ajYPc7mZcrWg+trEI/oXi81GMFaMX0BSUhwhbiN5+/Vb2wiG/Sn6ig==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
+      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.7.0.tgz",
-      "integrity": "sha512-PU5fo4Hh8y03LZgemgVREttc0wyHQUNmsJCybxTB7EjJie2CqJRumo+DFppArlvdchLwJdc9em03yQV/GNWrEg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
+      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
       "dev": true,
       "requires": {
-        "@parcel/fs-search": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.7.0"
-      }
-    },
-    "@parcel/fs-search": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.7.0.tgz",
-      "integrity": "sha512-K1Hv25bnRpwQVA15RvcRuB8ZhfclnCHA8N8L6w7Ul1ncSJDxCIkIAc5hAubYNNYW3kWjCC2SOaEgFKnbvMllEQ==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^1.0.3"
+        "@parcel/rust": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.12.0"
       }
     },
     "@parcel/graph": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.7.0.tgz",
-      "integrity": "sha512-Q6E94GS6q45PtsZh+m+gvFRp/N1Qopxhu2sxjcWsGs5iBd6IWn2oYLWOH5iVzEjWuYpW2HkB08lH6J50O63uOA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
+      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
       "dev": true,
       "requires": {
-        "@parcel/utils": "2.7.0",
         "nullthrows": "^1.1.1"
       }
     },
-    "@parcel/hash": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.7.0.tgz",
-      "integrity": "sha512-k6bSKnIlPJMPU3yjQzfgfvF9zuJZGOAlJgzpL4BbWvdbE8BTdjzLcFn0Ujrtud94EgIkiXd22sC2HpCUWoHGdA==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "xxhash-wasm": "^0.4.2"
-      }
-    },
     "@parcel/logger": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
-      "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
+      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
-      "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
+      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.7.0.tgz",
-      "integrity": "sha512-lIKMdsmi//7fepecNDYmJYzBlL91HifPsX03lJCdu1dC6q5fBs+gG0XjKKG7yPnSCw1qH/4m7drzt9+dRZYAHQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
+      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.7.0.tgz",
-      "integrity": "sha512-5UJQHalqMxdhJIs2hhqQzFfQpF7+NAowsRq064lYtiRvcD8wMr3OOQ9wd1iazGpFSl4JKdT7BwDU9/miDJmanQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
+      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.7.0.tgz",
-      "integrity": "sha512-IfnOMACqhcAclKyOW9X9JpsknB6OShk9OVvb8EvbDTKHJhQHNNmzE88OkSI/pS3ZVZP9Zj+nWcVHguV+kvDeiQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
+      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.7.0.tgz",
-      "integrity": "sha512-5QrGdWS5Hi4VXE3nQNrGqugmSXt68YIsWwKRAdarOxzyULSJS3gbCiQOXqIPRJobfZjnSIcdtkyxSiCUe1inIA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
+      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.12.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "svgo": "^2.4.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+          "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^6.0.1",
+            "domhandler": "^4.3.1",
+            "domutils": "^2.8.0",
+            "nth-check": "^2.0.1"
+          }
+        },
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "dev": true,
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "csso": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+          "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+          "dev": true,
+          "requires": {
+            "css-tree": "^1.1.2"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+          "dev": true
+        },
+        "svgo": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+          "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+          "dev": true,
+          "requires": {
+            "@trysound/sax": "0.2.0",
+            "commander": "^7.2.0",
+            "css-select": "^4.1.3",
+            "css-tree": "^1.1.3",
+            "csso": "^4.2.0",
+            "picocolors": "^1.0.0",
+            "stable": "^0.1.8"
+          }
+        }
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.7.0.tgz",
-      "integrity": "sha512-EnaXz5UjR67FUu0BEcqZTT9LsbB/iFAkkghCotbnbOuC5QQsloq6tw54TKU3y+R3qsjgUoMtGxPcGfVoXxZXYw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
+      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "detect-libc": "^1.0.3"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.7.0.tgz",
-      "integrity": "sha512-IO1JV4NpfP3V7FrhsqCcV8pDQIHraFi1/ZvEJyssITxjH49Im/txKlwMiQuZZryAPn8Xb8g395Muawuk6AK6sg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
+      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "svgo": "^2.4.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+          "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^6.0.1",
+            "domhandler": "^4.3.1",
+            "domutils": "^2.8.0",
+            "nth-check": "^2.0.1"
+          }
+        },
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "dev": true,
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "csso": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+          "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+          "dev": true,
+          "requires": {
+            "css-tree": "^1.1.2"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+          "dev": true
+        },
+        "svgo": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+          "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+          "dev": true,
+          "requires": {
+            "@trysound/sax": "0.2.0",
+            "commander": "^7.2.0",
+            "css-select": "^4.1.3",
+            "css-tree": "^1.1.3",
+            "csso": "^4.2.0",
+            "picocolors": "^1.0.0",
+            "stable": "^0.1.8"
+          }
+        }
       }
     },
-    "@parcel/optimizer-terser": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.7.0.tgz",
-      "integrity": "sha512-07VZjIO8xsl2/WmS/qHI8lI/cpu47iS9eRpqwfZEEsdk1cfz50jhWkmFudHBxiHGMfcZ//1+DdaPg9RDBWZtZA==",
+    "@parcel/optimizer-swc": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
+      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
-        "nullthrows": "^1.1.1",
-        "terser": "^5.2.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
+        "@swc/core": "^1.3.36",
+        "nullthrows": "^1.1.1"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.7.0.tgz",
-      "integrity": "sha512-wmfSX1mRrTi8MeA4KrnPk/x7zGUsILCQmTo6lA4gygzAxDbM1pGuyFN8/Kt0y0SFO2lbljARtD/4an5qdotH+Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
+      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "semver": "^5.7.1"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/core": "^1.3.36",
+        "semver": "^7.5.2"
       }
     },
     "@parcel/packager-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.7.0.tgz",
-      "integrity": "sha512-44nzZwu+ssGuiFmYM6cf/Y4iChiUZ4DUzzpegnGlhXtKJKe4NHntxThJynuRZWKN2AAf48avApDpimg2jW0KDw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
+      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.7.0.tgz",
-      "integrity": "sha512-Zgqd7sdcY/UnR370GR0q2ilmEohUDXsO8A1F28QCJzIsR1iCB6KRUT74+pawfQ1IhXZLaaFLLYe0UWcfm0JeXg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
+      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.7.0.tgz",
-      "integrity": "sha512-wTRdM81PgRVDzWGXdWmqLwguWnTYWzhEDdjXpW2n8uMOu/CjHhMtogk65aaYk3GOnq6OBL/NsrmBiV/zKPj1vA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
+      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.7.0.tgz",
-      "integrity": "sha512-jg2Zp8dI5VpIQlaeahXDCfrPN9m/DKht1NkR9P2CylMAwqCcc1Xc1RRiF0wfwcPZpPMpq1265n+4qnB7rjGBlA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
+      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.7.0.tgz",
-      "integrity": "sha512-EmJg3HpD6/xxKBjir/CdCKJZwI24iVfBuxRS9LUp3xHAIebOzVh1z6IN+i2Di5+NyRwfOFaLliL4uMa1zwbyCA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
+      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "posthtml": "^0.16.4"
       }
     },
-    "@parcel/plugin": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.7.0.tgz",
-      "integrity": "sha512-qqgx+nnMn6/0lRc4lKbLGmhNtBiT93S2gFNB4Eb4Pfz/SxVYoW+fmml+KdfOSiZffWOAH5L6NwhyD7N8aSikzw==",
+    "@parcel/packager-wasm": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
+      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.7.0"
+        "@parcel/plugin": "2.12.0"
+      }
+    },
+    "@parcel/plugin": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
+      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
+      "dev": true,
+      "requires": {
+        "@parcel/types": "2.12.0"
+      }
+    },
+    "@parcel/profiler": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
+      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "chrome-trace-event": "^1.0.2"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.7.0.tgz",
-      "integrity": "sha512-80gEODg8cnAmnxGVuaSVDo8JJ54P9AA2bHwSs1cIkHWlJ3BjDQb83H31bBHncJ5Kn5kQ/j+7WjlqHpTCiOR9PA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.12.0.tgz",
+      "integrity": "sha512-TqKsH4GVOLPSCanZ6tcTPj+rdVHERnt5y4bwTM82cajM21bCX1Ruwp8xOKU+03091oV2pv5ieB18pJyRF7IpIw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.7.0.tgz",
-      "integrity": "sha512-ySuou5addK8fGue8aXzo536BaEjMujDrEc1xkp4TasInXHVcA98b+SYX5NAZTGob5CxKvZQ5ylhg77zW30B+iA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
+      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
+      }
+    },
+    "@parcel/reporter-tracer": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
+      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "chrome-trace-event": "^1.0.3",
+        "nullthrows": "^1.1.1"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.7.0.tgz",
-      "integrity": "sha512-v8TvWsbLK7/q7n4gv6OrYNbW18xUx4zKbVMGZb1u4yMhzEH4HFr1D9OeoTq3jk+ximAigds8B6triQbL5exF7A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
+      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "2.7.0",
-        "@parcel/plugin": "2.7.0"
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.7.0.tgz",
-      "integrity": "sha512-PLbMLdclQeYsi2LkilZVGFV1n3y55G1jaBvby4ekedUZjMw3SWdMY2tDxgSDdFWfLCnYHJXdGUQSzGGi1kPzjA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
+      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.7.0.tgz",
-      "integrity": "sha512-9/YUZTBNrSN2H6rbz/o1EOM0O7I3ZR/x9IDzxjJBD6Mi+0uCgCD02aedare/SNr1qgnbZZWmhpOzC+YgREcfLA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
+      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.7.0.tgz",
-      "integrity": "sha512-vDKO0rWqRzEpmvoZ4kkYUiSsTxT5NnH904BFPFxKI0wJCl6yEmPuEifmATo73OuYhP6jIP3Qfl1R4TtiDFPJ1Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
+      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.7.0.tgz",
-      "integrity": "sha512-uD2pAV0yV6+e7JaWH4KVPbG+zRCrxr/OACyS9tIh+Q/R1vRmh8zGM3yhdrcoiZ7tFOnM72vd6xY11eTrUsSVig==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
+      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
+    "@parcel/rust": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
+      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
+      "dev": true
+    },
     "@parcel/source-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
-      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
+      "integrity": "sha512-Ejx1P/mj+kMjQb8/y5XxDUn4reGdr+WyKYloBljpppUy8gs42T+BNoEOuRYqDVdgPc6NxduzIDoJS9pOFfV5Ew==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.7.0.tgz",
-      "integrity": "sha512-7iklDXXnKH1530+QbI+e4kIJ+Q1puA1ulRS10db3aUJMj5GnvXGDFwhSZ7+T1ps66QHO7cVO29VlbqiRDarH1Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
+      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "semver": "^5.7.0"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.7.0.tgz",
-      "integrity": "sha512-J4EpWK9spQpXyNCmKK8Xnane0xW/1B/EAmfp7Fiv7g+5yUjY4ODf4KUugvE+Eb2gekPkhOKNHermO2KrX0/PFA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
+      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
       "dev": true,
       "requires": {
-        "@parcel/css": "^1.12.2",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.7.0.tgz",
-      "integrity": "sha512-wYJl5rn81W+Rlk9oQwDJcjoVsWVDKyeri84FzmlGXOsg0EYgnqOiG+3MDM8GeZjfuGe5fuoum4eqZeS0WdUHXw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
+      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
         "posthtml-render": "^3.0.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2",
+        "srcset": "4"
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.7.0.tgz",
-      "integrity": "sha512-mhi9/R5/ULhCkL2COVIKhNFoLDiZwQgprdaTJr5fnODggVxEX5o7ebFV6KNLMTEkwZUJWoB1hL0ziI0++DtoFA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
+      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.7.0.tgz",
-      "integrity": "sha512-mzerR+D4rDomUSIk5RSTa2w+DXBdXUeQrpDO74WCDdpDi1lIl8ppFpqtmU7O6y6p8QsgkmS9b0g/vhcry6CJTA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
+      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.7.0",
-        "@parcel/workers": "2.7.0",
-        "@swc/helpers": "^0.4.2",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
-        "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
         "regenerator-runtime": "^0.13.7",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.7.0.tgz",
-      "integrity": "sha512-RQjuxBpYOch+kr4a0zi77KJtOLTPYRM7iq4NN80zKnA0r0dwDUCxZBtaj2l0O0o3R4MMJnm+ncP+cB7XR7dZYA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
+      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
+        "@parcel/plugin": "2.12.0",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.7.0.tgz",
-      "integrity": "sha512-b6RskXBWf0MjpC9qjR2dQ1ZdRnlOiKYseG5CEovWCqM218RtdydFKz7jS+5Gxkb6qBtOG7zGPONXdPe+gTILcA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
+      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.7.0.tgz",
-      "integrity": "sha512-cP8YOiSynWJ1ycmBlhnnHeuQb2cwmklZ+BNyLUktj5p78kDy2de7VjX+dRNRHoW4H9OgEcSF4UEfDVVz5RYIhw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
+      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
         "posthtml-render": "^3.0.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.7.0.tgz",
-      "integrity": "sha512-sDnItWCFSDez0izK1i5cgv+kXzZTbcJh4rNpVIgmE1kBLvAz608sqgcCkavb2wVJIvLesxYM+5G4p1CwkDlZ1g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
+      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.7.0.tgz",
-      "integrity": "sha512-1vRmIJzyBA1nIiXTAU6tZExq2FvJj/2F0ft6KDw8GYPv0KjmdiPo/PmaZ7JeSVOM6SdXQIQCbTmp1vkMP7DtkA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
+      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-sass": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.7.0.tgz",
-      "integrity": "sha512-6m2T6Y5eQLX7ckIeuOjXXIZbzhyovnl69AvJ2FujoWb2nA55H/kg6ZdbKjo3CfXkOfg9LyG3nVnOE5PMgMpRFQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.12.0.tgz",
+      "integrity": "sha512-xLLoSLPST+2AHJwFRLl4foArDjjy6P1RChP3TxMU2MVS1sbKGJnfFhFpHAacH8ASjuGtu5rbpfpHRZePlvoZxw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
         "sass": "^1.38.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.7.0.tgz",
-      "integrity": "sha512-ioER37zceuuE+K6ZrnjCyMUWEnv+63hIAFResc1OXxRhyt+7kzMz9ZqK0Mt6QMLwl1dxhkLmrU41n9IxzKZuSQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
+      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/plugin": "2.7.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
         "posthtml-render": "^3.0.0",
-        "semver": "^5.7.1"
+        "semver": "^7.5.2"
       }
     },
     "@parcel/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-+dhXVUnseTCpJvBTGMp0V6X13z6O/A/+CUtwEpMGZ8XSmZ4Gk44GvaTiBOp0bJpWG4fvCKp+UmC8PYbrDiiziw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.7.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.12.0",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
-      "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
+      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/hash": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/markdown-ansi": "2.7.0",
-        "@parcel/source-map": "^2.0.0",
-        "chalk": "^4.1.0"
-      }
-    },
-    "@parcel/watcher": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.5.tgz",
-      "integrity": "sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==",
-      "dev": true,
-      "requires": {
-        "node-addon-api": "^3.2.1",
-        "node-gyp-build": "^4.3.0"
-      }
-    },
-    "@parcel/workers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.7.0.tgz",
-      "integrity": "sha512-99VfaOX+89+RaoTSyH9ZQtkMBFZBFMvJmVJ/GeJT6QCd2wtKBStTHlaSnQOkLD/iRjJCNwV2xpZmm8YkTwV+hg==",
-      "dev": true,
-      "requires": {
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/types": "2.7.0",
-        "@parcel/utils": "2.7.0",
-        "chrome-trace-event": "^1.0.2",
+        "@parcel/codeframe": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/markdown-ansi": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0",
         "nullthrows": "^1.1.1"
       }
     },
+    "@parcel/watcher": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
+      "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+      "dev": true,
+      "requires": {
+        "@parcel/watcher-android-arm64": "2.4.1",
+        "@parcel/watcher-darwin-arm64": "2.4.1",
+        "@parcel/watcher-darwin-x64": "2.4.1",
+        "@parcel/watcher-freebsd-x64": "2.4.1",
+        "@parcel/watcher-linux-arm-glibc": "2.4.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.4.1",
+        "@parcel/watcher-linux-arm64-musl": "2.4.1",
+        "@parcel/watcher-linux-x64-glibc": "2.4.1",
+        "@parcel/watcher-linux-x64-musl": "2.4.1",
+        "@parcel/watcher-win32-arm64": "2.4.1",
+        "@parcel/watcher-win32-ia32": "2.4.1",
+        "@parcel/watcher-win32-x64": "2.4.1",
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      }
+    },
+    "@parcel/watcher-android-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-darwin-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-darwin-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-freebsd-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-linux-arm64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-linux-x64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-linux-x64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-win32-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-win32-ia32": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-win32-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/workers": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
+      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "nullthrows": "^1.1.1"
+      }
+    },
+    "@swc/core": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.17.tgz",
+      "integrity": "sha512-tq+mdWvodMBNBBZbwFIMTVGYHe9N7zvEaycVVjfvAx20k1XozHbHhRv+9pEVFJjwRxLdXmtvFZd3QZHRAOpoNQ==",
+      "dev": true,
+      "requires": {
+        "@swc/core-darwin-arm64": "1.4.17",
+        "@swc/core-darwin-x64": "1.4.17",
+        "@swc/core-linux-arm-gnueabihf": "1.4.17",
+        "@swc/core-linux-arm64-gnu": "1.4.17",
+        "@swc/core-linux-arm64-musl": "1.4.17",
+        "@swc/core-linux-x64-gnu": "1.4.17",
+        "@swc/core-linux-x64-musl": "1.4.17",
+        "@swc/core-win32-arm64-msvc": "1.4.17",
+        "@swc/core-win32-ia32-msvc": "1.4.17",
+        "@swc/core-win32-x64-msvc": "1.4.17",
+        "@swc/counter": "^0.1.2",
+        "@swc/types": "^0.1.5"
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.17.tgz",
+      "integrity": "sha512-HVl+W4LezoqHBAYg2JCqR+s9ife9yPfgWSj37iIawLWzOmuuJ7jVdIB7Ee2B75bEisSEKyxRlTl6Y1Oq3owBgw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.17.tgz",
+      "integrity": "sha512-WYRO9Fdzq4S/he8zjW5I95G1zcvyd9yyD3Tgi4/ic84P5XDlSMpBDpBLbr/dCPjmSg7aUXxNQqKqGkl6dQxYlA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.17.tgz",
+      "integrity": "sha512-cgbvpWOvtMH0XFjvwppUCR+Y+nf6QPaGu6AQ5hqCP+5Lv2zO5PG0RfasC4zBIjF53xgwEaaWmGP5/361P30X8Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.17.tgz",
+      "integrity": "sha512-l7zHgaIY24cF9dyQ/FOWbmZDsEj2a9gRFbmgx2u19e3FzOPuOnaopFj0fRYXXKCmtdx+anD750iBIYnTR+pq/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.17.tgz",
+      "integrity": "sha512-qhH4gr9gAlVk8MBtzXbzTP3BJyqbAfUOATGkyUtohh85fPXQYuzVlbExix3FZXTwFHNidGHY8C+ocscI7uDaYw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.17.tgz",
+      "integrity": "sha512-vRDFATL1oN5oZMImkwbgSHEkp8xG1ofEASBypze01W1Tqto8t+yo6gsp69wzCZBlxldsvPpvFZW55Jq0Rn+UnA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.17.tgz",
+      "integrity": "sha512-zQNPXAXn3nmPqv54JVEN8k2JMEcMTQ6veVuU0p5O+A7KscJq+AGle/7ZQXzpXSfUCXlLMX4wvd+rwfGhh3J4cw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.17.tgz",
+      "integrity": "sha512-z86n7EhOwyzxwm+DLE5NoLkxCTme2lq7QZlDjbQyfCxOt6isWz8rkW5QowTX8w9Rdmk34ncrjSLvnHOeLY17+w==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.17.tgz",
+      "integrity": "sha512-JBwuSTJIgiJJX6wtr4wmXbfvOswHFj223AumUrK544QV69k60FJ9q2adPW9Csk+a8wm1hLxq4HKa2K334UHJ/g==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.17.tgz",
+      "integrity": "sha512-jFkOnGQamtVDBm3MF5Kq1lgW8vx4Rm1UvJWRUfg+0gx7Uc3Jp3QMFeMNw/rDNQYRDYPG3yunCC+2463ycd5+dg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
+    },
     "@swc/helpers": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
-      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
+      }
+    },
+    "@swc/types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
+      "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+      "dev": true,
+      "requires": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true
-    },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/prop-types": {
@@ -4298,35 +5311,24 @@
       "dev": true
     },
     "@typescript/ata": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@typescript/ata/-/ata-0.9.3.tgz",
-      "integrity": "sha512-/mETZakA5iOT8j8N8/ZUPLEsvSgMJz+cWt9Le1Q9dEwRXwDzekKXw3tpgrq77gaSxgE/Mn/nvtx8uzS41CmZKQ==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@typescript/ata/-/ata-0.9.4.tgz",
+      "integrity": "sha512-PaJ16WouPV/SaA+c0tnOKIqYq24+m93ipl/e0Dkxuianer+ibc5b0/6ZgfCFF8J7QEp57dySMSP9nWOFaCfJnw==",
       "requires": {}
     },
     "@typescript/sandbox": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript/sandbox/-/sandbox-0.1.0.tgz",
-      "integrity": "sha512-f2pUCF3aNk3cdOuL0M7k8Vgzl4/P3ltgoZ5QWILqwp8Fb3SqLPKFSlTIKmn7Y8B7ojSz0tNQsZwH1syN6gAoSw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@typescript/sandbox/-/sandbox-0.1.2.tgz",
+      "integrity": "sha512-ncMaLNwC76leRfRvzkZn5oujEb/7EPqWuPfObG/mJWyjXNmct1PW9+cruJDUCU7Ntc4K10oMf3HEYZCp6FCs3Q==",
       "requires": {
-        "@typescript/ata": "0.9.3",
-        "@typescript/vfs": "1.3.5"
-      },
-      "dependencies": {
-        "@typescript/vfs": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.3.5.tgz",
-          "integrity": "sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==",
-          "requires": {
-            "debug": "^4.1.1"
-          }
-        }
+        "@typescript/ata": "0.9.4",
+        "@typescript/vfs": "1.5.0"
       }
     },
     "@typescript/vfs": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.4.0.tgz",
-      "integrity": "sha512-Pood7yv5YWMIX+yCHo176OnF8WUlKGImFG7XlsuH14Zb1YN5+dYD3uUtS7lqZtsH7tAveNUi2NzdpQCN0yRbaw==",
-      "dev": true,
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.0.tgz",
+      "integrity": "sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==",
       "requires": {
         "debug": "^4.1.1"
       }
@@ -4335,12 +5337,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
       "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
-      "dev": true
-    },
-    "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "ansi-styles": {
@@ -4361,6 +5357,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "base-x": {
       "version": "3.0.9",
@@ -4420,12 +5422,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4433,9 +5429,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001399",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
-      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
+      "version": "1.0.30001614",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz",
+      "integrity": "sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==",
       "dev": true
     },
     "chalk": {
@@ -4502,40 +5498,78 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "requires": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      }
-    },
     "css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
       }
     },
     "css-what": {
@@ -4545,12 +5579,36 @@
       "dev": true
     },
     "csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
-        "css-tree": "^1.1.2"
+        "css-tree": "~2.2.0"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+          "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "mdn-data": "2.0.28",
+            "source-map-js": "^1.0.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.28",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+          "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "csstype": {
@@ -4700,9 +5758,9 @@
       }
     },
     "globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -4715,14 +5773,36 @@
       "dev": true
     },
     "htmlnano": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.0.2.tgz",
-      "integrity": "sha512-+ZrQFS4Ub+zd+/fWwfvoYCEGNEa0/zrpys6CyXxvZDwtL7Pl+pOtRkiujyvBQ7Lmfp7/iEPxtOFgxWA16Gkj3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.0.tgz",
+      "integrity": "sha512-jVGRE0Ep9byMBKEu0Vxgl8dhXYOUk0iNQ2pjsG+BcRB0u0oDF5A9p/iBGMg/PGKYUyMD0OAGu8dVT5Lzj8S58g==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^7.0.1",
+        "cosmiconfig": "^8.0.0",
         "posthtml": "^0.16.5",
         "timsort": "^0.3.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.2.0",
+            "path-type": "^4.0.0"
+          }
+        },
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "htmlparser2": {
@@ -4821,6 +5901,15 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -4853,75 +5942,83 @@
       }
     },
     "lightningcss": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.14.0.tgz",
-      "integrity": "sha512-Vwa1JWiLGRLntf4TXRu/zF2RaHRfJjbZwUzkl2C4LhnRQzsEwkyeAQjAxtpJ5NDnVVUf10q1olEzkFF4AWZLOw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.1.tgz",
+      "integrity": "sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "lightningcss-darwin-arm64": "1.14.0",
-        "lightningcss-darwin-x64": "1.14.0",
-        "lightningcss-linux-arm-gnueabihf": "1.14.0",
-        "lightningcss-linux-arm64-gnu": "1.14.0",
-        "lightningcss-linux-arm64-musl": "1.14.0",
-        "lightningcss-linux-x64-gnu": "1.14.0",
-        "lightningcss-linux-x64-musl": "1.14.0",
-        "lightningcss-win32-x64-msvc": "1.14.0"
+        "lightningcss-darwin-arm64": "1.24.1",
+        "lightningcss-darwin-x64": "1.24.1",
+        "lightningcss-freebsd-x64": "1.24.1",
+        "lightningcss-linux-arm-gnueabihf": "1.24.1",
+        "lightningcss-linux-arm64-gnu": "1.24.1",
+        "lightningcss-linux-arm64-musl": "1.24.1",
+        "lightningcss-linux-x64-gnu": "1.24.1",
+        "lightningcss-linux-x64-musl": "1.24.1",
+        "lightningcss-win32-x64-msvc": "1.24.1"
       }
     },
     "lightningcss-darwin-arm64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.14.0.tgz",
-      "integrity": "sha512-AFt8Qs9Qjbg5AlB/3cYljanVEeyJI4C9bPqO8hI7bNa2HdDIINI4NgfGpri8BNwA3zcAlFPH38caIqcG3LWC+g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.1.tgz",
+      "integrity": "sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==",
       "dev": true,
       "optional": true
     },
     "lightningcss-darwin-x64": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.14.0.tgz",
-      "integrity": "sha512-xF9YSNxHiAOyYp5/Ogo4K+SybcQExWUi+vkIGnpO6zQsQda7KFgJt2aA3AwaEj9ouf2yUHHKcsk2TiixlZTtTg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.1.tgz",
+      "integrity": "sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.1.tgz",
+      "integrity": "sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.14.0.tgz",
-      "integrity": "sha512-8cH/qwZnoU3zIruVNWGLBDVm6f1w/ZC3eMDkFOTEF4FaW3jCpxEg/BH5r04lNUM/SO6Zu2C+vgJaEKdUm58dQg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.1.tgz",
+      "integrity": "sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.14.0.tgz",
-      "integrity": "sha512-88NmNwTRa10MRDJa2DghZuGZq8rvFeZIm0G4k/oA2P5XaJJw7f6IhDEjCtBoruYOZhulBkEq2xQY+q0AWYMFcw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.1.tgz",
+      "integrity": "sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.14.0.tgz",
-      "integrity": "sha512-8FSXmV7yPqk+1vErgdEO6OvDXDT/MkJMF+jSaUuL5wEvCC5yiJsaktNEJvn5EHsFbODi9DNvUt71sjeFCJma1w==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.1.tgz",
+      "integrity": "sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.14.0.tgz",
-      "integrity": "sha512-+dcNezLgUdAozcc6c0YSnZyRcOpro/yOOdy6ZjIwQtxej/5sEVJhXWbyHhdwSSlJssg/d+/7ihxEJIdZ8oDIfw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.1.tgz",
+      "integrity": "sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.14.0.tgz",
-      "integrity": "sha512-TI8tIaYv6SBpoBGatCG8gKQMxMCUcc+rvBSrqU7geHFBwzzyxOEHflENMclfwiYjTEM/HMdgJbWuHsIY3xvkuQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.1.tgz",
+      "integrity": "sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.14.0.tgz",
-      "integrity": "sha512-l2H8GoDn+WJAENKrIgNgRunqP3gvyBQwBmFqIXpuxx9G6ll2aTlyQsvsVxzJWJ5ePl3atNRGFQO+ZkiTNSm71A==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.1.tgz",
+      "integrity": "sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==",
       "dev": true,
       "optional": true
     },
@@ -4932,28 +6029,28 @@
       "dev": true
     },
     "lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.8.5.tgz",
+      "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "requires": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2",
-        "msgpackr": "^1.5.4",
-        "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.3",
-        "ordered-binary": "^1.2.4",
+        "@lmdb/lmdb-darwin-arm64": "2.8.5",
+        "@lmdb/lmdb-darwin-x64": "2.8.5",
+        "@lmdb/lmdb-linux-arm": "2.8.5",
+        "@lmdb/lmdb-linux-arm64": "2.8.5",
+        "@lmdb/lmdb-linux-x64": "2.8.5",
+        "@lmdb/lmdb-win32-x64": "2.8.5",
+        "msgpackr": "^1.9.5",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.1.1",
+        "ordered-binary": "^1.4.1",
         "weak-lru-cache": "^1.2.2"
       },
       "dependencies": {
         "node-addon-api": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
           "dev": true
         }
       }
@@ -4966,16 +6063,37 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "monaco-editor": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.32.1.tgz",
-      "integrity": "sha512-LUt2wsUvQmEi2tfTOK+tjAPvt7eQ+K5C4rZPr6SeuyzjAuAHrIvlUloTcOiGjZW3fn3a/jFQCONrEJbNOaCqbA==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.45.0.tgz",
+      "integrity": "sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA==",
       "dev": true
     },
     "ms": {
@@ -4984,47 +6102,61 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msgpackr": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.2.tgz",
-      "integrity": "sha512-bqSQ0DYJbXbrJcrZFmMygUZmqQiDfI2ewFVWcrZY12w5XHWtPuW4WppDT/e63Uu311ajwkRRXSoF0uILroBeTA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "dev": true,
       "requires": {
-        "msgpackr-extract": "^2.0.2"
+        "msgpackr-extract": "^3.0.2"
       }
     },
     "msgpackr-extract": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.1.2.tgz",
-      "integrity": "sha512-cmrmERQFb19NX2JABOGtrKdHMyI6RUyceaPBQ2iRz9GnDkjBWFjNJC0jyyoOfZl2U/LZE3tQCCQc4dlRyA8mcA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
       "dev": true,
       "optional": true,
       "requires": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.1.2",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.1.2",
-        "node-gyp-build-optional-packages": "5.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2",
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "dependencies": {
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+          "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "dev": true
-    },
-    "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
       "dev": true
     },
     "node-gyp-build-optional-packages": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
-      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^2.0.1"
+      },
+      "dependencies": {
+        "detect-libc": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+          "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+          "dev": true
+        }
+      }
     },
     "node-releases": {
       "version": "2.0.6",
@@ -5059,9 +6191,9 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "ordered-binary": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.3.0.tgz",
-      "integrity": "sha512-knIeYepTI6BDAzGxqFEDGtI/iGqs57H32CInAIxEvAHG46vk1Di0CEpyc1A7iY39B1mfik3g3KLYwOTNnnMHLA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
+      "integrity": "sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A==",
       "dev": true
     },
     "pako": {
@@ -5070,25 +6202,25 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parcel": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.7.0.tgz",
-      "integrity": "sha512-pRYwnivwtNP0tip8xYSo4zCB0XhLt7/gJzP1p8OovCqkmFjG9VG+GW9TcAKqMIo0ovEa9tT+/s6gY1Qy+BONGQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
+      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.7.0",
-        "@parcel/core": "2.7.0",
-        "@parcel/diagnostic": "2.7.0",
-        "@parcel/events": "2.7.0",
-        "@parcel/fs": "2.7.0",
-        "@parcel/logger": "2.7.0",
-        "@parcel/package-manager": "2.7.0",
-        "@parcel/reporter-cli": "2.7.0",
-        "@parcel/reporter-dev-server": "2.7.0",
-        "@parcel/utils": "2.7.0",
+        "@parcel/config-default": "2.12.0",
+        "@parcel/core": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/reporter-cli": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/reporter-tracer": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
-        "get-port": "^4.2.0",
-        "v8-compile-cache": "^2.0.0"
+        "get-port": "^4.2.0"
       }
     },
     "parent-module": {
@@ -5289,9 +6421,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "resolve-from": {
@@ -5326,10 +6458,13 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -5348,15 +6483,11 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
+    "srcset": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+      "dev": true
     },
     "stable": {
       "version": "0.1.8",
@@ -5389,18 +6520,20 @@
       }
     },
     "svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
       }
     },
     "term-size": {
@@ -5408,26 +6541,6 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
       "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true
-    },
-    "terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        }
-      }
     },
     "timsort": {
       "version": "0.3.0",
@@ -5445,9 +6558,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "type-fest": {
@@ -5477,15 +6590,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
-      "dev": true
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "dev": true
     },
     "warning": {
@@ -5502,16 +6609,10 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
     },
-    "xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Playground environment for building Web Extensions",
   "scripts": {
     "start": "npx parcel src/index.html",
-    "build": "rm -rf dist && npx parcel build src/index.html --no-source-maps"
+    "build": "rm -rf dist && ./build_workers.sh && npx parcel build src/index.html --no-source-maps"
   },
   "author": "Oliver Dunk",
   "license": "MIT",
@@ -12,23 +12,23 @@
     "cssModules": true
   },
   "devDependencies": {
-    "@parcel/transformer-sass": "^2.6.2",
+    "@parcel/transformer-sass": "2.12.0",
     "@types/react-dom": "^18.0.5",
     "@types/react-modal": "^3.13.1",
     "@typescript/vfs": "^1.3.5",
     "buffer": "^6.0.3",
-    "monaco-editor": "^0.32.1",
-    "parcel": "^2.6.2",
+    "monaco-editor": "0.45.0",
+    "parcel": "2.12.0",
     "prettier": "2.7.1",
     "process": "^0.11.10",
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@typescript/sandbox": "0.1.2",
     "jszip": "^3.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
-    "react-modal": "^3.15.1",
-    "@typescript/sandbox": "0.1.0"
+    "react-modal": "^3.15.1"
   }
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -64,6 +64,7 @@ export function Sidebar() {
         <ul>
           {templates.map((t) => (
             <li
+              key={t.name}
               data-disabled={t.filter?.(playgroundState) === false}
               data-selected={selectedTemplate === t ? "true" : undefined}
               onClick={() => {
@@ -78,6 +79,7 @@ export function Sidebar() {
         <ul>
           {browsers.map((b: Browser) => (
             <li
+              key={b}
               data-disabled={
                 selectedTemplate.filter?.({
                   ...playgroundState,
@@ -95,6 +97,7 @@ export function Sidebar() {
         <ul>
           {manifestVersions.map((v: "MV2" | "MV3") => (
             <li
+              key={v}
               data-disabled={
                 selectedTemplate.filter?.({
                   ...playgroundState,
@@ -111,6 +114,7 @@ export function Sidebar() {
         <h2>Settings</h2>
         <ul>
           <li
+            key="polyfill"
             onClick={() =>
               setStateWithConfirmation({
                 includePolyfill: !playgroundState.includePolyfill,
@@ -125,6 +129,7 @@ export function Sidebar() {
             )}
           </li>
           <li
+            key="theme"
             onClick={() =>
               setPlaygroundState({
                 ...playgroundState,

--- a/src/utils/sandbox.ts
+++ b/src/utils/sandbox.ts
@@ -4,15 +4,28 @@ import {
   SandboxConfig,
 } from "@typescript/sandbox";
 
+import * as monaco from "monaco-editor";
+import * as typescript from "typescript";
+
 import browserTypesUrl from "url:../static/browser.d.ts.txt";
 
-window.require.config({
-  paths: {
-    vs: "https://typescript.azureedge.net/cdn/4.0.5/monaco/min/vs",
+self.MonacoEnvironment = {
+  getWorkerUrl: function (moduleId, label) {
+    if (label === "json") {
+      return "./json.worker.js";
+    }
+    if (label === "css" || label === "scss" || label === "less") {
+      return "./css.worker.js";
+    }
+    if (label === "html" || label === "handlebars" || label === "razor") {
+      return "./html.worker.js";
+    }
+    if (label === "typescript" || label === "javascript") {
+      return "./ts.worker.js";
+    }
+    return "./editor.worker.js";
   },
-  // This is something you need for monaco to work
-  ignoreDuplicateModules: ["vs/editor/editor.main"],
-});
+};
 
 export async function loadSandbox(): Promise<Sandbox> {
   const browserTypesResponse = await fetch(browserTypesUrl);
@@ -24,34 +37,33 @@ export async function loadSandbox(): Promise<Sandbox> {
   const chromeTypes = await chromeTypesResponse.text();
 
   return new Promise((resolve) => {
-    window.require(
-      ["vs/editor/editor.main", "vs/language/typescript/tsWorker"],
-      (main: typeof import("monaco-editor")) => {
-        const sandboxConfig: SandboxConfig = {
-          text: "",
-          compilerOptions: {},
-          domID: "editor",
-          monacoSettings: {
-            // @ts-expect-error This type is missing from the Monaco types
-            tabSize: 2,
-            automaticLayout: true,
-            wordWrap: "on",
-          },
-          // TODO: We default this to false, since we don't want to promise types
-          // for packages which aren't installed, but we should provide users
-          // with a way to enable it.
-          acquireTypes: false,
-        };
+    const sandboxConfig: SandboxConfig = {
+      text: "",
+      compilerOptions: {},
+      domID: "editor",
+      monacoSettings: {
+        // @ts-expect-error This type is missing from the Monaco types
+        tabSize: 2,
+        automaticLayout: true,
+        wordWrap: "on",
+      },
+      // TODO: We default this to false, since we don't want to promise types
+      // for packages which aren't installed, but we should provide users
+      // with a way to enable it.
+      acquireTypes: false,
+    };
 
-        const sandbox = createTypeScriptSandbox(sandboxConfig, main, window.ts);
-        sandbox.languageServiceDefaults.setExtraLibs([
-          { content: browserTypes, filePath: "browser.d.ts" },
-          { content: chromeTypes, filePath: "chrome.d.ts" },
-        ]);
-        sandbox.editor.focus();
+    const sandbox = createTypeScriptSandbox(sandboxConfig, monaco, typescript);
+    sandbox.languageServiceDefaults.setExtraLibs([
+      { content: browserTypes, filePath: "browser.d.ts" },
+      { content: chromeTypes, filePath: "chrome.d.ts" },
+    ]);
+    sandbox.editor.focus();
 
-        resolve(sandbox);
-      }
-    );
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      allowComments: true,
+    });
+
+    resolve(sandbox);
   });
 }


### PR DESCRIPTION
Upgrades the version of `monaco-editor` to expose new APIs which may be useful for future work. At the same time:

- Begin bundling monaco locally to avoid loading from a remote source
- Enable comments in JSON files including manifest.json
- Add keys to a number of React elements to prevent console warnings
- Upgrade a number of other dependencies
- Lock dependency versions