### PR TITLE
Add action to side panel template in Chrome

### DIFF
--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -87,6 +87,9 @@ export function generateManifest(
   if (manifest.sidepanelPath) {
     switch (browser) {
       case "Chrome":
+        result["action"] = {
+          default_title: "Open side panel",
+        };
         result["side_panel"] = {
           default_path: manifest.sidepanelPath,
         };

--- a/src/templates/sidePanel.ts
+++ b/src/templates/sidePanel.ts
@@ -18,7 +18,7 @@ export const SidePanel: Template = {
       text: (context) =>
         `
 ${context.global}.runtime.onInstalled.addListener((details) => {
-  console.log("Extension has been installed. Reason:", details.reason);
+  console.log("Extension has been installed. Reason:", details.reason);${context.browser === "Chrome" ? "\n  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });" : ""}
 });
 
 console.log("Hello World!");


### PR DESCRIPTION
Chrome no longer has default UI for opening an extension side panel, so extensions need to provide an explicit way of opening it. Update the template with this in mind.